### PR TITLE
Use odbr:: prefix for internal functions

### DIFF
--- a/R/read_dictionary.R
+++ b/R/read_dictionary.R
@@ -31,10 +31,10 @@ read_dictionary <- function(city = "S\u00E3o Paulo",
                             harmonize = FALSE,
                             language = "pt") {
   # Clean the name of the city before comparing to the metadata
-  city_clean <- clean_string(city)
+  city_clean <- odbr::clean_string(city)
 
   # Argument check - error message if it is passed a non-existent city parameter
-  if (!city_clean %in% clean_string(odbr::metadata$city)) {
+  if (!city_clean %in% odbr::clean_string(odbr::metadata$city)) {
     usethis::ui_stop("The specified city ({city}) is not available.
                      Check the metadata object for available cities and cohorts.")
   }
@@ -58,8 +58,8 @@ read_dictionary <- function(city = "S\u00E3o Paulo",
   }
 
   # Creating the dictionary filename
-  language_text <- clean_string(language)
-  od_dic_name <- paste0(compose_name(city, year, harmonize), "_dictionary_", language_text)
+  language_text <- odbr::clean_string(language)
+  od_dic_name <- paste0(odbr::compose_name(city, year, harmonize), "_dictionary_", language_text)
 
   # Get the correct dictionary
   od_dic <- get0(od_dic_name, envir = asNamespace("odbr"))

--- a/R/read_map.R
+++ b/R/read_map.R
@@ -48,10 +48,10 @@ read_map <- function(city = "S\u00E3o Paulo",
                      harmonize = FALSE,
                      geometry = "zone") {
   # Clean the name of the city before comparing to the metadata
-  city_clean <- clean_string(city)
+  city_clean <- odbr::clean_string(city)
 
   # Argument check - error message if it is passed a non-existent city parameter
-  if (!city_clean %in% clean_string(odbr::metadata$city)) {
+  if (!city_clean %in% odbr::clean_string(odbr::metadata$city)) {
     usethis::ui_stop("The specified city ({city}) is not available.
                    Check the metadata object for available cities and cohorts.")
   }
@@ -69,15 +69,15 @@ read_map <- function(city = "S\u00E3o Paulo",
   }
 
   # Creating the filename to download
-  filename_to_download <- paste0(compose_name(city,
-                                              year,
-                                              harmonize,
-                                              geometry),
+  filename_to_download <- paste0(odbr::compose_name(city,
+                                                    year,
+                                                    harmonize,
+                                                    geometry),
                                  ".gpkg")
 
   # Calling the "download_piggyback" function with "filename_to_download" as
   # parameter and saving the function return in "temporary_filename"
-  temporary_filename <- download_piggyback(filename_to_download)
+  temporary_filename <- odbr::download_piggyback(filename_to_download)
 
   # Reading shape files
   od_map <- sf::read_sf(temporary_filename)

--- a/R/read_od.R
+++ b/R/read_od.R
@@ -27,10 +27,10 @@ read_od <- function(city = "S\u00E3o Paulo",
                     year = 2017,
                     harmonize = FALSE) {
   # Clean the name of the city before comparing to the metadata
-  city_clean <- clean_string(city)
+  city_clean <- odbr::clean_string(city)
 
   # Argument check - error message if it is passed a non-existent city parameter
-  if (!city_clean %in% clean_string(odbr::metadata$city)) {
+  if (!city_clean %in% odbr::clean_string(odbr::metadata$city)) {
     usethis::ui_stop("The specified city ({city}) is not available.
                    Check the metadata object for available cities and cohorts.")
   }
@@ -48,11 +48,11 @@ read_od <- function(city = "S\u00E3o Paulo",
   }
 
   # Creating the filename to download
-  filename_to_download <- paste0(compose_name(city, year, harmonize), ".csv.gz")
+  filename_to_download <- paste0(odbr::compose_name(city, year, harmonize), ".csv.gz")
 
   # Calling the "download_piggyback" function with "filename_to_download" as
   # parameter and saving the function return in "temporary_filename"
-  temporary_filename <- download_piggyback(filename_to_download)
+  temporary_filename <- odbr::download_piggyback(filename_to_download)
 
   # Reading the file to a release in odbr repository
   od_file <- data.table::fread(temporary_filename,


### PR DESCRIPTION
To be a bit more "rigorous" and also because the linter is complaining about it.