### PR TITLE
Do not run slow examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,9 +9,9 @@ Authors@R: c(
     person("Rafael H. M.", "Pereira", , "rafa.pereira.br@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-2125-7465"))
   )
-Description: Download Data from Brazil's Origin Destination Surveys. Until
-    now, this package provides the raw information from the São Paulo OD
-    surveys, for all the years available.
+Description: Provide access to data and metadata from Brazil's Origin
+    Destination Surveys. Please check the package metada (or documentation) for
+    the available surveys.
 License: GPL (>=3)
 Depends: 
     R (>= 2.10)

--- a/R/read_map.R
+++ b/R/read_map.R
@@ -17,32 +17,33 @@
 #' @family Geometry
 #'
 #' @examples
-#' library(odbr)
+#' \dontrun{
+#'   library(odbr)
 #'
-#' # return zone data from OD Surveys database as sf object at a given city and year
-#' df <- read_map(
-#'   city = "Sao Paulo",
-#'   year = 2017,
-#'   harmonize = FALSE,
-#'   geometry = "zone"
-#' )
+#'   # return zone data from OD Surveys database as sf object at a given city and year
+#'   df <- read_map(
+#'     city = "Sao Paulo",
+#'     year = 2017,
+#'     harmonize = FALSE,
+#'     geometry = "zone"
+#'   )
 #'
-#' #' # return district data from OD Surveys database as sf object at a given city and year
-#' df <- read_map(
-#'   city = "Sao Paulo",
-#'   year = 2017,
-#'   harmonize = FALSE,
-#'   geometry = "district"
-#' )
+#'   #' # return district data from OD Surveys database as sf object at a given city and year
+#'   df <- read_map(
+#'     city = "Sao Paulo",
+#'     year = 2017,
+#'     harmonize = FALSE,
+#'     geometry = "district"
+#'   )
 #'
-#' # return municipality data from OD Surveys database as sf object at a given city and year
-#' df <- read_map(
-#'   city = "Sao Paulo",
-#'   year = 2017,
-#'   harmonize = FALSE,
-#'   geometry = "municipality"
-#' )
-#'
+#'   # return municipality data from OD Surveys database as sf object at a given city and year
+#'   df <- read_map(
+#'     city = "Sao Paulo",
+#'     year = 2017,
+#'     harmonize = FALSE,
+#'     geometry = "municipality"
+#'   )
+#' }
 read_map <- function(city = "S\u00E3o Paulo",
                      year = 2017,
                      harmonize = FALSE,

--- a/R/read_od.R
+++ b/R/read_od.R
@@ -15,14 +15,15 @@
 #'
 #' @examples
 #' library(odbr)
+#' \dontrun{
 #'
-#' # return data from OD Surveys database as data.frame
-#' df <- read_od(
-#'   city = "Sao Paulo",
-#'   year = 2017,
-#'   harmonize = FALSE
-#' )
-#'
+#'   # return data from OD Surveys database as data.frame
+#'   df <- read_od(
+#'     city = "Sao Paulo",
+#'     year = 2017,
+#'     harmonize = FALSE
+#'   )
+#' }
 read_od <- function(city = "S\u00E3o Paulo",
                     year = 2017,
                     harmonize = FALSE) {


### PR DESCRIPTION
CRAN has a limit of 5 seconds to run the examples. Since we rely on
downloading large files, it usually take more than 5 seconds as a
default, failing the "Checking examples" check from CRAN. So, the
proposed approach here is to "Skip"  running these examples.

Due to the fact that we indeed have tests covering these functions,
skipping this "doc examples" execution won't impact in the project
coverage.

Additionally, I've also changed the DESCRIPTION description to avoid CRAN issues with "Paulo" word from São Paulo name.