### PR TITLE
Improve download file handling

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -1,20 +1,21 @@
 # The "download_piggyback" function requires as parameter the filename_to_download
 download_piggyback <- function(filename_to_download) {
-  # Defining a temporary file path and saving it in "temp"
-  temp <- fs::file_temp()
+  # Defining our temporary directory
+  temp_dest_dir <- tempdir(check = TRUE)
 
   # Creating the temporary folder effectively
-  fs::dir_create(temp)
+  fs::dir_create(path = temp_dest_dir, recurse = TRUE)
 
   # Creating path + filename and saving to "temporary_filename"
-  temporary_filename <- paste0(temp, "/", filename_to_download)
+  temp_full_file_path <- paste0(temp_dest_dir, "/", filename_to_download)
 
   # Uploading the file to a release of the odbr repo - release specified in the parameter
   piggyback::pb_download(
     file = filename_to_download,
     repo = "hsvab/odbr",
-    dest = temp
+    dest = temp_dest_dir
   )
+
   # The function returns the R object "temporary_filename"
-  return(temporary_filename)
+  return(temp_full_file_path)
 }

--- a/R/download.R
+++ b/R/download.R
@@ -1,5 +1,5 @@
 # The "download_piggyback" function requires as parameter the filename_to_download
-download_piggyback <- function(filename_to_download) {
+download_piggyback <- function(filename_to_download, force_download = FALSE) {
   # Defining our temporary directory
   temp_dest_dir <- tempdir(check = TRUE)
 
@@ -9,7 +9,7 @@ download_piggyback <- function(filename_to_download) {
   # Creating path + filename and saving to "temporary_filename"
   temp_full_file_path <- paste0(temp_dest_dir, "/", filename_to_download)
 
-  if (!file.exists(temp_full_file_path)) {
+  if (!file.exists(temp_full_file_path) || force_download) {
     # Uploading the file to a release of the odbr repo - release specified in the parameter
     piggyback::pb_download(
       file = filename_to_download,

--- a/R/download.R
+++ b/R/download.R
@@ -9,12 +9,14 @@ download_piggyback <- function(filename_to_download) {
   # Creating path + filename and saving to "temporary_filename"
   temp_full_file_path <- paste0(temp_dest_dir, "/", filename_to_download)
 
-  # Uploading the file to a release of the odbr repo - release specified in the parameter
-  piggyback::pb_download(
-    file = filename_to_download,
-    repo = "hsvab/odbr",
-    dest = temp_dest_dir
-  )
+  if (!file.exists(temp_full_file_path)) {
+    # Uploading the file to a release of the odbr repo - release specified in the parameter
+    piggyback::pb_download(
+      file = filename_to_download,
+      repo = "hsvab/odbr",
+      dest = temp_dest_dir
+    )
+  }
 
   # The function returns the R object "temporary_filename"
   return(temp_full_file_path)

--- a/R/read_map.R
+++ b/R/read_map.R
@@ -11,6 +11,7 @@
 #' @template harmonize
 #' @param geometry Character. The type of spatial data to be opened. Options
 #' include `c("zone","district", "municipality")`.
+#' @template force_download
 #'
 #' @return An `"sf" "data.frame"` object
 #' @export
@@ -46,7 +47,8 @@
 read_map <- function(city = "S\u00E3o Paulo",
                      year = 2017,
                      harmonize = FALSE,
-                     geometry = "zone") {
+                     geometry = "zone",
+                     force_download = FALSE) {
   # Clean the name of the city before comparing to the metadata
   city_clean <- clean_string(city)
 
@@ -75,7 +77,7 @@ read_map <- function(city = "S\u00E3o Paulo",
 
   # Calling the "download_piggyback" function with "filename_to_download" as
   # parameter and saving the function return in "temporary_filename"
-  temporary_filename <- download_piggyback(filename_to_download)
+  temporary_filename <- download_piggyback(filename_to_download, force_download)
 
   # Reading shape files
   od_map <- sf::read_sf(temporary_filename)

--- a/R/read_od.R
+++ b/R/read_od.R
@@ -8,6 +8,7 @@
 #' @template city
 #' @template year
 #' @template harmonize
+#' @template force_download
 #'
 #' @return A `"data.frame"` object.
 #' @export
@@ -25,7 +26,8 @@
 #'
 read_od <- function(city = "S\u00E3o Paulo",
                     year = 2017,
-                    harmonize = FALSE) {
+                    harmonize = FALSE,
+                    force_download = FALSE) {
   # Clean the name of the city before comparing to the metadata
   city_clean <- clean_string(city)
 
@@ -45,7 +47,7 @@ read_od <- function(city = "S\u00E3o Paulo",
 
   # Calling the "download_piggyback" function with "filename_to_download" as
   # parameter and saving the function return in "temporary_filename"
-  temporary_filename <- download_piggyback(filename_to_download)
+  temporary_filename <- download_piggyback(filename_to_download, force_download)
 
   # Reading the file to a release in odbr repository
   od_file <- data.table::fread(temporary_filename,

--- a/man/read_map.Rd
+++ b/man/read_map.Rd
@@ -4,7 +4,13 @@
 \alias{read_map}
 \title{Download spatial data from OD Surveys databases}
 \usage{
-read_map(city = "São Paulo", year = 2017, harmonize = FALSE, geometry = "zone")
+read_map(
+  city = "São Paulo",
+  year = 2017,
+  harmonize = FALSE,
+  geometry = "zone",
+  force_download = FALSE
+)
 }
 \arguments{
 \item{city}{Character. City of reference. Defaults to "São Paulo".}
@@ -18,6 +24,9 @@ city, across all the years.}
 
 \item{geometry}{Character. The type of spatial data to be opened. Options
 include \code{c("zone","district", "municipality")}.}
+
+\item{force_download}{Boolean. If we should download the data file again even
+if it was already downloaded. Defaults to FALSE.}
 }
 \value{
 An \verb{"sf" "data.frame"} object

--- a/man/read_od.Rd
+++ b/man/read_od.Rd
@@ -4,7 +4,12 @@
 \alias{read_od}
 \title{Download microdata from OD Surveys databases}
 \usage{
-read_od(city = "São Paulo", year = 2017, harmonize = FALSE)
+read_od(
+  city = "São Paulo",
+  year = 2017,
+  harmonize = FALSE,
+  force_download = FALSE
+)
 }
 \arguments{
 \item{city}{Character. City of reference. Defaults to "São Paulo".}
@@ -15,6 +20,9 @@ read_od(city = "São Paulo", year = 2017, harmonize = FALSE)
 \item{harmonize}{Logical. When \code{FALSE} (Default), the function returns the raw
 data. If \code{TRUE}, the function returns harmonized data to the same
 city, across all the years.}
+
+\item{force_download}{Boolean. If we should download the data file again even
+if it was already downloaded. Defaults to FALSE.}
 }
 \value{
 A \code{"data.frame"} object.

--- a/man/roxygen/templates/force_download.R
+++ b/man/roxygen/templates/force_download.R
@@ -1,0 +1,2 @@
+#' @param force_download Boolean. If we should download the data file again even
+#'             if it was already downloaded. Defaults to FALSE.


### PR DESCRIPTION
Ensure files are being downloaded to a temporary directory in the system default temporary directory, instead of a random directory within userspace (or package directory).

Also implement a logic to check if the file was already downloaded and skip downloading it again.

Finally, it was also implemented a new argument to some functions to allow forcing the redownload of the file on users desire.

Ps: This PR is better reviewed commit per commit.

Closes #32 
Closes #10