### PR TITLE
Script to download and rename shapefiles, so we can create the geopackages for OD SP 2023

### DIFF
--- a/data-raw/sao_paulo/download-and-rename-shapefiles.R
+++ b/data-raw/sao_paulo/download-and-rename-shapefiles.R
@@ -1,0 +1,62 @@
+# Saving gkpg --------------
+
+# Composing the name of the new directory ------------------
+city <- "sao_paulo"
+year <- 2023
+directory <- paste0("data-raw/", city, "/", year, "/not_harmonized/")
+
+
+# Create directory ----------------
+dir.create(directory)
+
+# Download zip file ---------------------------
+# Be careful not to upload this to GitHub.
+# It is a large file!
+
+destfile_path <- paste0(directory, "pesquisa_od.zip")
+
+download.file(url = "https://transparencia.metrosp.com.br/sites/default/files/Site_190225_PesquisaOD2023.zip", destfile = destfile_path)
+
+# Unzip the file -----------
+
+zip::unzip(zipfile = destfile_path, exdir = directory)
+
+
+# List files in the directory
+
+ls_dir <- list.files(directory, recursive = TRUE, full.names = TRUE)
+
+# Finding shapefiles in the directory ----
+
+shapefiles <- stringr::str_subset(ls_dir, ".shp$|.shx$|.dbf$|.prj$|.cpg") |>
+  stringr::str_subset("Municipios|Distritos|Zonas")
+
+# Copy shapefiles to the new directory ----
+fs::file_copy(shapefiles, directory)
+
+
+# Finding new shapefiles in the directory ----
+
+ls_dir_2 <- list.files(directory, recursive = FALSE, full.names = TRUE)
+
+shapefiles_2 <- stringr::str_subset(ls_dir_2, ".shp$|.shx$|.dbf$|.prj$|.cpg") |>
+  stringr::str_subset("Municipios|Distritos|Zonas")
+
+
+# Check if names are following the pattern -------
+
+rename_files <- function(name) {
+  file_name <- basename(name)
+  level <- stringr::str_extract(file_name, "Municipios|Distritos|Zonas")
+  year <- stringr::str_extract(file_name, "[0-9]{4}")
+  file_extension <- tools::file_ext(file_name)
+  new_name <- paste0(level, year, "_region.", file_extension)
+  new_path <- stringr::str_replace(name, file_name, new_name)
+  fs::file_move(name, new_path)
+
+}
+
+possibly_rename_files <- purrr::possibly(rename_files, otherwise = NULL)
+
+# Rename files ----
+purrr::map(shapefiles_2, possibly_rename_files)

--- a/data-raw/sao_paulo/download-and-rename-shapefiles.R
+++ b/data-raw/sao_paulo/download-and-rename-shapefiles.R
@@ -15,7 +15,14 @@ dir.create(directory)
 
 destfile_path <- paste0(directory, "pesquisa_od.zip")
 
-download.file(url = "https://transparencia.metrosp.com.br/sites/default/files/Site_190225_PesquisaOD2023.zip", destfile = destfile_path)
+
+zip_file <- paste0(
+  "https://transparencia.metrosp.com.br/sites/",
+  "default/files/Site_190225_PesquisaOD2023.zip"
+)
+
+
+download.file(url = zip_file, destfile = destfile_path)
 
 # Unzip the file -----------
 
@@ -53,7 +60,6 @@ rename_files <- function(name) {
   new_name <- paste0(level, year, "_region.", file_extension)
   new_path <- stringr::str_replace(name, file_name, new_name)
   fs::file_move(name, new_path)
-
 }
 
 possibly_rename_files <- purrr::possibly(rename_files, otherwise = NULL)


### PR DESCRIPTION
This is related to #48

 
@hsvab  asked me how did we generate the `.gpkg` files for the previous OD data, so she could run for 2023.

This happens in the file `data-raw/sao_paulo/prep_data-sao_paulo.R`:
https://github.com/hsvab/odbr/blob/02d0bc6662db242039dbbe5652f0578f5bccb639/data-raw/sao_paulo/prep_data-sao_paulo.R#L27-L92

More especifically, in this part:
https://github.com/hsvab/odbr/blob/02d0bc6662db242039dbbe5652f0578f5bccb639/data-raw/sao_paulo/prep_data-sao_paulo.R#L75-L80

BUT the `.shp` file has to have an exact file name in order for this code to work.
For example:
```
> filename_map
[1] "data-raw/sao_paulo/2023/not_harmonized/Zonas2023_region.shp"
```

In the file `data-raw/download-and-rename-shapefiles.R` (created in this PR) I documented the process of downloading the `.zip` from OD São Paulo 2023, moving and renaming the files so it works when you run the code in `data-raw/sao_paulo/prep_data-sao_paulo.R`. 

Let me know if this helped or if you need anything else! 

Bea
